### PR TITLE
Fix compilation with clang and -std=c++11

### DIFF
--- a/sauce/internal/base_injector.h
+++ b/sauce/internal/base_injector.h
@@ -67,7 +67,7 @@ public:
   void validateAcyclic(bool validateProviding, InjectorPtr injector, TypeIds & ids, std::string const name) const {
     typedef typename Key<Dependency>::Normalized Normalized;
     CircularDependencyGuard<ImplicitBindings, Normalized> guard(ids, name);
-    bindings.validateAcyclic<Normalized>(validateProviding, injector, ids, name);
+    bindings.template validateAcyclic<Normalized>(validateProviding, injector, ids, name);
   }
 
   template<typename Dependency>
@@ -81,7 +81,7 @@ public:
 
   template<typename Scope>
   void eagerlyInject(InjectorPtr injector) const {
-    bindings.eagerlyInject<Scope>(injector);
+    bindings.template eagerlyInject<Scope>(injector);
   }
 
   /**

--- a/sauce/internal/method_binding.h
+++ b/sauce/internal/method_binding.h
@@ -53,7 +53,7 @@ class MethodBinding: public Binding<Dependency, NoScope> {
         InjectorPtr & injector = passed.injector;
         std::string dependencyName = binding.dynamicDependencyNames[i];
 
-        return this->template injectHelper<T>(binding, injector, dependencyName);
+        return this->MethodBindingFriend::template injectHelper<T>(binding, injector, dependencyName);
       }
     };
   };
@@ -85,7 +85,7 @@ class MethodBinding: public Binding<Dependency, NoScope> {
         TypeIds & ids = passed.ids;
         std::string dependencyName = binding.dynamicDependencyNames[i];
 
-        this->template validateAcyclicHelper<T>(binding, injector, ids, dependencyName);
+        this->MethodBindingFriend::template validateAcyclicHelper<T>(binding, injector, ids, dependencyName);
       }
     };
   };

--- a/sauce/internal/new_binding.h
+++ b/sauce/internal/new_binding.h
@@ -58,7 +58,7 @@ class NewBinding: public Binding<Dependency, Scope> {
         InjectorPtr & injector = passed.injector;
         std::string dependencyName = binding.dynamicDependencyNames[i];
 
-        return this->template injectHelper<T>(binding, injector, dependencyName);
+        return this->NewBindingFriend::template injectHelper<T>(binding, injector, dependencyName);
       }
     };
   };
@@ -91,7 +91,7 @@ class NewBinding: public Binding<Dependency, Scope> {
         TypeIds & ids = passed.ids;
         std::string dependencyName = binding.dynamicDependencyNames[i];
 
-        this->template validateAcyclicHelper<T>(binding, injector, ids, dependencyName);
+        this->NewBindingFriend::template validateAcyclicHelper<T>(binding, injector, ids, dependencyName);
       }
     };
   };


### PR DESCRIPTION
Without this patch I used to get following errors:

```
In file included from /Users/aa/projects/ununu/ungine/main.cpp:3:
In file included from /Users/aa/projects/ununu/deps/sauce/sauce/sauce.h:4:
In file included from /Users/aa/projects/ununu/deps/sauce/sauce/binder.h:12:
In file included from /Users/aa/projects/ununu/deps/sauce/sauce/internal/clause.h:11:
In file included from /Users/aa/projects/ununu/deps/sauce/sauce/internal/instance_binding.h:4:
In file included from /Users/aa/projects/ununu/deps/sauce/sauce/injector.h:10:
/Users/aa/projects/ununu/deps/sauce/sauce/internal/base_injector.h:70:14: error: use 'template' keyword to treat 'validateAcyclic' as a dependent template name
    bindings.validateAcyclic<Normalized>(validateProviding, injector, ids, name);
             ^
             template 
/Users/aa/projects/ununu/deps/sauce/sauce/internal/base_injector.h:84:14: error: use 'template' keyword to treat 'eagerlyInject' as a dependent template name
    bindings.eagerlyInject<Scope>(injector);
             ^
             template 
In file included from /Users/aa/projects/ununu/ungine/main.cpp:3:
In file included from /Users/aa/projects/ununu/deps/sauce/sauce/sauce.h:4:
In file included from /Users/aa/projects/ununu/deps/sauce/sauce/binder.h:12:
In file included from /Users/aa/projects/ununu/deps/sauce/sauce/internal/clause.h:12:
/Users/aa/projects/ununu/deps/sauce/sauce/internal/method_binding.h:56:31: error: 'injectHelper' following the 'template' keyword does not refer to a template
        return this->template injectHelper<T>(binding, injector, dependencyName);
                     ~~~~~~~~ ^~~~~~~~~~~~
/Users/aa/projects/ununu/deps/sauce/sauce/internal/method_binding.h:56:43: error: expected unqualified-id
        return this->template injectHelper<T>(binding, injector, dependencyName);
                                          ^
/Users/aa/projects/ununu/deps/sauce/sauce/internal/method_binding.h:56:44: error: 'T' does not refer to a value
        return this->template injectHelper<T>(binding, injector, dependencyName);
                                           ^
/Users/aa/projects/ununu/deps/sauce/sauce/internal/method_binding.h:46:23: note: declared here
    template<typename T, int i>
                      ^
/Users/aa/projects/ununu/deps/sauce/sauce/internal/method_binding.h:88:24: error: 'validateAcyclicHelper' following the 'template' keyword does not refer to a template
        this->template validateAcyclicHelper<T>(binding, injector, ids, dependencyName);
              ~~~~~~~~ ^~~~~~~~~~~~~~~~~~~~~
/Users/aa/projects/ununu/deps/sauce/sauce/internal/method_binding.h:88:45: error: expected unqualified-id
        this->template validateAcyclicHelper<T>(binding, injector, ids, dependencyName);
                                            ^
/Users/aa/projects/ununu/deps/sauce/sauce/internal/method_binding.h:88:46: error: 'T' does not refer to a value
        this->template validateAcyclicHelper<T>(binding, injector, ids, dependencyName);
                                             ^
/Users/aa/projects/ununu/deps/sauce/sauce/internal/method_binding.h:77:23: note: declared here
    template<typename T, int i>
                      ^
In file included from /Users/aa/projects/ununu/ungine/main.cpp:3:
In file included from /Users/aa/projects/ununu/deps/sauce/sauce/sauce.h:4:
In file included from /Users/aa/projects/ununu/deps/sauce/sauce/binder.h:12:
In file included from /Users/aa/projects/ununu/deps/sauce/sauce/internal/clause.h:13:
/Users/aa/projects/ununu/deps/sauce/sauce/internal/new_binding.h:61:31: error: 'injectHelper' following the 'template' keyword does not refer to a template
        return this->template injectHelper<T>(binding, injector, dependencyName);
                     ~~~~~~~~ ^~~~~~~~~~~~
/Users/aa/projects/ununu/deps/sauce/sauce/internal/new_binding.h:61:43: error: expected unqualified-id
        return this->template injectHelper<T>(binding, injector, dependencyName);
                                          ^
/Users/aa/projects/ununu/deps/sauce/sauce/internal/new_binding.h:61:44: error: 'T' does not refer to a value
        return this->template injectHelper<T>(binding, injector, dependencyName);
                                           ^
/Users/aa/projects/ununu/deps/sauce/sauce/internal/new_binding.h:51:23: note: declared here
    template<typename T, int i>
                      ^
/Users/aa/projects/ununu/deps/sauce/sauce/internal/new_binding.h:94:24: error: 'validateAcyclicHelper' following the 'template' keyword does not refer to a template
        this->template validateAcyclicHelper<T>(binding, injector, ids, dependencyName);
              ~~~~~~~~ ^~~~~~~~~~~~~~~~~~~~~
/Users/aa/projects/ununu/deps/sauce/sauce/internal/new_binding.h:94:45: error: expected unqualified-id
        this->template validateAcyclicHelper<T>(binding, injector, ids, dependencyName);
                                            ^
/Users/aa/projects/ununu/deps/sauce/sauce/internal/new_binding.h:94:46: error: 'T' does not refer to a value
        this->template validateAcyclicHelper<T>(binding, injector, ids, dependencyName);
                                             ^
/Users/aa/projects/ununu/deps/sauce/sauce/internal/new_binding.h:85:23: note: declared here
    template<typename T, int i>
                      ^

```
